### PR TITLE
feat: Supports wireless tuning via TCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## *Simple**FOC**Studio*
 
-Graphical user interface for the [*Simple**FOC**library*](https://github.com/simplefoc). This application allows to tune and configure any BLDC/Stepper *Simple**FOC**library* controlled device, using serial port communications and the [Commander](https://docs.simplefoc.com/commander_interface) interface.
+Graphical user interface for the [*Simple**FOC**library*](https://github.com/simplefoc). This application allows to tune and configure any BLDC/Stepper *Simple**FOC**library* controlled device, using serial port communications or wireless connections with the the [Commander](https://docs.simplefoc.com/commander_interface) interface.
 #### The main features are:
 
 - Plug and play with the *Simple**FOC**library* version 2.1

--- a/src/gui/configtool/connectionControl.py
+++ b/src/gui/configtool/connectionControl.py
@@ -3,7 +3,7 @@
 from PyQt5 import QtWidgets
 
 from src.gui.configtool.configureConnectionDialog import \
-    ConfigureSerailConnectionDialog
+    ConfigureConnectionDialog
 from src.gui.sharedcomnponets.sharedcomponets import GUIToolKit
 from src.simpleFOCConnector import SimpleFOCDevice
 
@@ -77,8 +77,8 @@ class ConnectionControlGroupBox(QtWidgets.QGroupBox):
             self.connectDisconnectButton.setText('Connect')
 
     def configureDeviceAction(self):
-        dialog = ConfigureSerailConnectionDialog()
+        dialog = ConfigureConnectionDialog()
         result = dialog.exec_()
         if result:
-            deviceConfig = dialog.getConfigValues()
-            self.device.configureConnection(deviceConfig)
+            connType, deviceConfig = dialog.getConfigValues()
+            self.device.configureConnection(connType, deviceConfig)


### PR DESCRIPTION
On some moving objects, connecting to SimpleFOC Studio via serial port can be somewhat inconvenient (though using a wireless serial connection is also an option). For existing embedded controllers like the ESP32, WiFi support is available. Therefore, we want to enable SimpleFOC Studio to connect to SimpleFOC hardware via a wireless network.

On the Arduino side, we can directly adapt and use the [wireless tuning library](https://github.com/SmallPond/WirelessTuning) without modifying the Simple FOC library.

<img width="1300" alt="Snipaste_2024-08-30_23-58-53" src="https://github.com/user-attachments/assets/647ebbc8-08c9-4239-b53d-8544b98b0ae7">
