### PR TITLE
Use line width=1 in graphicWidget.py to reduce lag

### DIFF
--- a/src/gui/configtool/graphicWidget.py
+++ b/src/gui/configtool/graphicWidget.py
@@ -51,7 +51,7 @@ class SimpleFOCGraphicWidget(QtWidgets.QGroupBox):
             # define signal plot data array
             self.signalDataArrays.append(np.zeros(self.numberOfSamples))
             # configure signal plot parameters
-            signalPen = pg.mkPen(color=sigColor, width=1.5)
+            signalPen = pg.mkPen(color=sigColor, width=1)
             self.signalPlots.append(pg.PlotDataItem(self.timeArray,
                                             self.signalDataArrays[-1],
                                             pen=signalPen, name=tooltip))


### PR DESCRIPTION
A line width of more than 1 causes lag in some graphs. Reducing the line width to 1 fixes the performance. 

See JorgeMaker/SimpleFOCStudio#30 and pyqtgraph/pyqtgraph#533 for more context. 
